### PR TITLE
Fix ponder crashes when calling FluidTankBlockEntity#getControllerBE

### DIFF
--- a/src/main/java/com/tiestoettoet/create_train_parts/foundation/ponder/CreateTrainPartsPonderPlugin.java
+++ b/src/main/java/com/tiestoettoet/create_train_parts/foundation/ponder/CreateTrainPartsPonderPlugin.java
@@ -41,12 +41,7 @@ public class CreateTrainPartsPonderPlugin implements PonderPlugin {
 //        helper.registerSharedText("behaviour_modify_value_panel", "This behaviour can be modified using the value panel");
 //        helper.registerSharedText("storage_on_contraption", "Inventories attached to the Contraption will pick up their drops automatically");
 //    }
-
-    @Override
-    public void onPonderLevelRestore(PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
-    }
-
+//
 //    @Override
 //    public void indexExclusions(IndexExclusionHelper helper) {
 //        helper.excludeBlockVariants(ValveHandleBlock.class, AllBlocks.COPPER_VALVE_HANDLE.get());


### PR DESCRIPTION
`CreateTrainPartsPonderPlugin#onPonderLevelRestore` calls `PonderWorldBlockEntityFix#fixControllerBlockEntities`, which causes controller BE position being adjusted twice. Because `PonderWorldBlockEntityFix#fixControllerBlockEntities` is applied globally instead of seperately and already been called by `CreatePonderPlugin`.